### PR TITLE
Handle MySQL port configuration consistently

### DIFF
--- a/advisor_service/README.md
+++ b/advisor_service/README.md
@@ -58,7 +58,7 @@ Before running the project, ensure you have the following tools and libraries in
    MYSQL_USER=your_mysql_user
    MYSQL_PASSWORD=your_mysql_password
    MYSQL_HOST=your_mysql_host
-   MYSQL_PORT=your_mysql_port
+   MYSQL_PORT=3306  # Default MySQL port
    MYSQL_DATABASE_DW=your_mysql_dw_database
    ```
 

--- a/advisor_service/configuration/config.py
+++ b/advisor_service/configuration/config.py
@@ -1,13 +1,12 @@
 from dotenv import load_dotenv
 import os
-import sys
 load_dotenv()
 
 class Config:
     MYSQL_USER = os.getenv('MYSQL_USER')
     MYSQL_PASSWORD = os.getenv('MYSQL_PASSWORD')
     MYSQL_HOST = os.getenv('MYSQL_HOST')
-    MYSQL_PORT = os.getenv('MYSQL_PORT')
+    MYSQL_PORT = int(os.getenv('MYSQL_PORT', 3306))
     MYSQL_DATABASE_DW = os.getenv('MYSQL_DATABASE_DW')
     MYSQL_DATABASE_OLTP = os.getenv('MYSQL_DATABASE_OLTP')
     TRAINED_MODEL_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../models'))

--- a/advisor_service/notebooks/movie_advisor_algorithm.ipynb
+++ b/advisor_service/notebooks/movie_advisor_algorithm.ipynb
@@ -59,9 +59,9 @@
     "username = os.getenv('MYSQL_USER')\n",
     "password = os.getenv('MYSQL_PASSWORD')\n",
     "host = os.getenv('MYSQL_HOST')\n",
-    "port = os.getenv('MYSQL_PORT')\n",
+    "port = int(os.getenv('MYSQL_PORT', 3306))\n",
     "database = os.getenv('MYSQL_DATABASE_DW')\n",
-    "uri = f\"mysql://{username}:{password}@{host}/{database}\"\n",
+    "uri = f\"mysql://{username}:{password}@{host}:{port}/{database}\"\n",
     "print(uri)\n",
     "\n",
     "dw_engine = db.create_engine(uri)"
@@ -275,7 +275,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(Tab(children=(Tab(children=(GridBox(children=(VBox(children=(GridspecLayout(children=(HTML(valu…"
+       "VBox(children=(Tab(children=(Tab(children=(GridBox(children=(VBox(children=(GridspecLayout(children=(HTML(valu\u2026"
       ]
      },
      "metadata": {},

--- a/data_warehouse/README.md
+++ b/data_warehouse/README.md
@@ -30,7 +30,7 @@ Before running this project, ensure you have the following tools and libraries i
    MYSQL_USER=your_mysql_user
    MYSQL_PASSWORD=your_mysql_password
    MYSQL_HOST=your_mysql_host
-   MYSQL_PORT=your_mysql_port
+   MYSQL_PORT=3306  # Default MySQL port
    MYSQL_DATABASE_DW=your_mysql_dw_database
    MYSQL_DATABASE_OLTP=your_mysql_oltp_database
 

--- a/data_warehouse/configuration/config.py
+++ b/data_warehouse/configuration/config.py
@@ -6,7 +6,7 @@ class Config:
     MYSQL_USER = os.getenv('MYSQL_USER')
     MYSQL_PASSWORD = os.getenv('MYSQL_PASSWORD')
     MYSQL_HOST = os.getenv('MYSQL_HOST')
-    MYSQL_PORT = os.getenv('MYSQL_PORT')
+    MYSQL_PORT = int(os.getenv('MYSQL_PORT', 3306))
     MYSQL_DATABASE_DW = os.getenv('MYSQL_DATABASE_DW')
     MYSQL_DATABASE_OLTP = os.getenv('MYSQL_DATABASE_OLTP')
 

--- a/data_warehouse/notebooks/oltp_ETL.ipynb
+++ b/data_warehouse/notebooks/oltp_ETL.ipynb
@@ -43,9 +43,9 @@
     "username = os.getenv('MYSQL_USER')\n",
     "password = os.getenv('MYSQL_PASSWORD')\n",
     "host = os.getenv('MYSQL_HOST')\n",
-    "port = os.getenv('MYSQL_PORT')\n",
+    "port = int(os.getenv('MYSQL_PORT', 3306))\n",
     "database = os.getenv('MYSQL_DATABASE_DW')\n",
-    "uri = f\"mysql://{username}:{password}@{host}/{database}\"\n",
+    "uri = f\"mysql://{username}:{password}@{host}:{port}/{database}\"\n",
     "print(uri)\n",
     "\n",
     "dw_engine = db.create_engine(uri)"
@@ -82,9 +82,9 @@
     "username = os.getenv('MYSQL_USER')\n",
     "password = os.getenv('MYSQL_PASSWORD')\n",
     "host = os.getenv('MYSQL_HOST')\n",
-    "port = os.getenv('MYSQL_PORT')\n",
+    "port = int(os.getenv('MYSQL_PORT', 3306))\n",
     "database = os.getenv('MYSQL_DATABASE_OLTP')\n",
-    "uri = f\"mysql://{username}:{password}@{host}/{database}\"\n",
+    "uri = f\"mysql://{username}:{password}@{host}:{port}/{database}\"\n",
     "print(uri)\n",
     "\n",
     "connection_OLTP = db.create_engine(uri)"

--- a/data_warehouse/src/db_connection.py
+++ b/data_warehouse/src/db_connection.py
@@ -9,7 +9,7 @@ def connect_to_mysql(database):
     password = Config.MYSQL_PASSWORD
     host = Config.MYSQL_HOST
     port = Config.MYSQL_PORT
-    uri = f"mysql://{username}:{password}@{host}/{database}"
+    uri = f"mysql://{username}:{password}@{host}:{port}/{database}"
     print(uri)
     return db.create_engine(uri)
 


### PR DESCRIPTION
- include MySQL port when building connection URIs
- parse `MYSQL_PORT` as an integer with a default of 3306 and drop unused imports
- update notebooks and docs to use the new port handling