### PR TITLE
Rename score column and update README

### DIFF
--- a/data_warehouse/README.md
+++ b/data_warehouse/README.md
@@ -41,6 +41,11 @@ Before running this project, ensure you have the following tools and libraries i
    MONGODB_CLUSTER_NAME=your_mongodb_cluster_name
    ```
 
+4. **(Optional) Run the test suite** to verify your environment:
+   ```bash
+   pytest
+   ```
+
 ## Repository Structure
 
 ```plaintext

--- a/data_warehouse/src/transform.py
+++ b/data_warehouse/src/transform.py
@@ -25,21 +25,20 @@ def transform_excel_data(df_movies,df_recommendations):
   df_movie_scores['recommendations'] = df_movie_scores['name'].map(df_recommendations['movie'].value_counts())
   df_movie_scores['score'] = df_movie_scores['recommendations'].apply(lambda x: assign_score(total_recommendations_by_movie.quantile(0.75), total_recommendations_by_movie.median(), x))
 
-  df_movie_scores= df_movie_scores[['name', 'score']].rename(columns={
-    'name': 'title',
-    'calculated_score': 'peopleScore'
+  df_movie_scores = df_movie_scores[["name", "score"]].rename(columns={
+    "name": "title",
+    "score": "peopleScore",
   })
-  df_movie_scores['netflixScore'] = None
-  df_movie_scores['imdbScore'] = None
-  df_movie_scores['rottentomatoesScore'] = None
-  df_movie_scores['sensacineScore'] = None
-  df_movie_scores['peopleComment'] = df_movie_scores['score'].apply(lambda x: generate_comment(x))
+  df_movie_scores["netflixScore"] = None
+  df_movie_scores["imdbScore"] = None
+  df_movie_scores["rottentomatoesScore"] = None
+  df_movie_scores["sensacineScore"] = None
+  df_movie_scores["peopleComment"] = df_movie_scores["peopleScore"].apply(lambda x: generate_comment(x))
 
   #prepare dimScore DataFrame
   df_dim_score = df_movie_scores.copy()
-  df_dim_score.drop(columns=['title'], inplace=True)
-  df_dim_score.rename(columns={'score': "peopleScore"}, inplace=True)
-  df_dim_score = df_dim_score.reset_index(names='scoreID')
+  df_dim_score.drop(columns=["title"], inplace=True)
+  df_dim_score = df_dim_score.reset_index(names="scoreID")
 
   # Apply the function to generate interaction data for each recommendation
   interactions_data = df_recommendations.apply(generate_interaction_data, axis=1)


### PR DESCRIPTION

- Rename `score` to `peopleScore` during Excel data transformation and adjust downstream column usage
- Document optional `pytest` step in data warehouse README
