### PR TITLE
Fix data warehouse package init and streamline imports

### DIFF
--- a/data_warehouse/README.md
+++ b/data_warehouse/README.md
@@ -72,6 +72,11 @@ data_warehouse/
 - `requirements.txt`: List of required Python libraries.
 - `README.md`: Project documentation.
 
+The `src` directory is a proper Python package (it includes an `__init__.py` file),
+which allows modules inside it to be imported directly without using `src.`
+prefixes. Ensure you execute commands from the `data_warehouse` directory so
+these imports resolve correctly.
+
 ## Running the ETL Process
 
 To run the ETL process, execute the following command:

--- a/data_warehouse/src/main.py
+++ b/data_warehouse/src/main.py
@@ -14,7 +14,12 @@ from extract import (
     extract_mongo_interactions,
     extract_mongo_movies,
 )
-from src.load import load_data, load_dim_tables, prepare_fact_watchs_excel, prepare_fact_watchs_mongo
+from load import (
+    load_data,
+    load_dim_tables,
+    prepare_fact_watchs_excel,
+    prepare_fact_watchs_mongo,
+)
 
 
 def etl_excel():


### PR DESCRIPTION
## Summary
- Rename misnamed `__ini__.py` to `__init__.py` so `src` functions as a proper package
- Clean up imports in `src/main.py` to remove unnecessary `src.` prefix and format for clarity
- Update data warehouse README with notes about the `src` package and usage

## Testing
- `python data_warehouse/src/main.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r data_warehouse/requirements.txt` *(fails: Could not connect to proxy: 403 Forbidden)*
- `jupyter nbconvert --to notebook --execute data_warehouse/notebooks/excel_ETL.ipynb --output /tmp/excel_ETL.out.ipynb` *(fails: command not found)
- `pip install jupyter` *(fails: Could not connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae774aa7f88320b67338338dafe7e6